### PR TITLE
Replace trilom/file-changes-action with tj-actions/changed-files

### DIFF
--- a/.github/workflows/code-quality-pr.yaml
+++ b/.github/workflows/code-quality-pr.yaml
@@ -32,14 +32,14 @@ jobs:
 
       - name: Find modified files
         id: file_changes
-        uses: trilom/file-changes-action@v1.2.4
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
-          output: " "
+          separator: " "
 
       - name: List modified files
-        run: echo '${{ steps.file_changes.outputs.files}}'
+        run: echo '${{ steps.file_changes.outputs.all_changed_files }}'
 
       - name: Run pre-commits
         uses: pre-commit/action@v3.0.1
         with:
-          extra_args: --files ${{ steps.file_changes.outputs.files}}
+          extra_args: --files ${{ steps.file_changes.outputs.all_changed_files }}


### PR DESCRIPTION
## Summary

- Swaps the unmaintained `trilom/file-changes-action@v1.2.4` (last released 2020, uses a deprecated Node runtime) for the actively maintained `tj-actions/changed-files`.
- Pinned by commit SHA (`9426d40…` = `v47.0.6`) per GitHub's [supply-chain hardening guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) — matters here because `tj-actions/changed-files` had a high-profile compromise in March 2025.
- Input/output name changes:
  - `output: " "` → `separator: " "` (same space-joined behavior for `pre-commit --files`)
  - `steps.file_changes.outputs.files` → `steps.file_changes.outputs.all_changed_files`

Closes #4

## Test plan

- [ ] CI `Code Quality PR` job on this PR runs to completion.
- [ ] The "List modified files" step prints a space-separated list of the files touched in this PR (just `.github/workflows/code-quality-pr.yaml`).
- [ ] `pre-commit` runs against that file and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)